### PR TITLE
241017 add resume consumer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,9 @@ services:
     working_dir: /app
     env_file:
       - .env.webrtc
+    environment:
+      DEBUG: "mediasoup*"
+      TZ: 'Asia/Tokyo'
     ports:
       - "50000-50100:50000-50100/udp"
     volumes:
@@ -29,6 +32,8 @@ services:
     container_name: videmus-webserver
     ports:
       - 80:80
+    environment:
+      TZ: 'Asia/Tokyo'
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf
 

--- a/next/.dockerignore
+++ b/next/.dockerignore
@@ -1,4 +1,1 @@
 node_modules/
-.next/
-.env*
-

--- a/next/Dockerfile.nextjs.prod
+++ b/next/Dockerfile.nextjs.prod
@@ -1,0 +1,14 @@
+FROM node:20
+
+WORKDIR /app
+
+COPY . .
+
+RUN npm install -g pnpm
+
+RUN pnpm install
+
+RUN pnpm build
+
+CMD ["pnpm", "start"]
+

--- a/next/src/app/stream/[streamId]/page.tsx
+++ b/next/src/app/stream/[streamId]/page.tsx
@@ -2,14 +2,17 @@
 import WebRtcVideo from '@/components/WebRtcVideo';
 
 const StreamPage: React.FC<{
-  params: {
+  params: Promise<{
     streamId: string
-  }
-}> = ({ params }) => {
+  }>
+}> = async ({ params }) => {
+
+  const { streamId } = await params;
+
   return (
     <div>
       <div>ストリーミング用ページ</div>
-      <WebRtcVideo streamId={params.streamId} />
+      <WebRtcVideo streamId={streamId} />
     </div>
   );
 };

--- a/next/src/lib/webRtcClient.ts
+++ b/next/src/lib/webRtcClient.ts
@@ -16,20 +16,16 @@ export const createWebRtcStreams = async (
     `${baseUrl}/mediasoup/router-rtp-capabilities/${streamId}`
   );
   const routerRtpCapabilities = await routerRtpCapabilitiesResponse.json();
-  console.log('routerRtpCapabilities: %o', routerRtpCapabilities);
   const device = new Device();
   await device.load({ routerRtpCapabilities });
   const transportParametersResponse = await fetch(
     `${baseUrl}/mediasoup/streamer-transport-parameters/${streamId}`
   );
   const transportParameters = await transportParametersResponse.json();
-  console.log('transportParmaeters: %o', transportParameters);
   const transport = device.createRecvTransport(transportParameters);
-  console.log('is server transport id and recvtransport id is the same?: ', transportParameters.id === transport.id);
   transport.on(
     'connect', 
     async ({ dtlsParameters }, callback, errback) => {
-      console.log('transport connect');
       try {
         await fetch(
           `${baseUrl}/mediasoup/client-connect/${streamId}/${transportParameters.id}`, {
@@ -47,9 +43,6 @@ export const createWebRtcStreams = async (
       }
     }
   );
-  transport.on('connectionstatechange', (newConnectionState) => {
-    console.log('connection stage: ', newConnectionState);
-  });
 
   const consumerParametersResponse = await fetch(
     `${baseUrl}/mediasoup/consumer-parameters/${streamId}/${transportParameters.id}`, {

--- a/next/src/lib/webRtcClient.ts
+++ b/next/src/lib/webRtcClient.ts
@@ -62,6 +62,15 @@ export const createWebRtcStreams = async (
   for (const consumerParameter of consumerParameters) {
     consumers.push(await transport.consume(consumerParameter));
   }
+  //consumers.forEach(c => c.resume());
+  const resumeConsumerResponse = await fetch(
+    `${baseUrl}/mediasoup/resume-consumer/${streamId}/${transportParameters.id}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+  });
+  if (!resumeConsumerResponse.ok) {
+    throw new Error('server consumer resume request failed.');
+  }
   return consumers;
 }
 

--- a/next/src/lib/webRtcClient.ts
+++ b/next/src/lib/webRtcClient.ts
@@ -25,6 +25,7 @@ export const createWebRtcStreams = async (
   const transportParameters = await transportParametersResponse.json();
   console.log('transportParmaeters: %o', transportParameters);
   const transport = device.createRecvTransport(transportParameters);
+  console.log('is server transport id and recvtransport id is the same?: ', transportParameters.id === transport.id);
   transport.on(
     'connect', 
     async ({ dtlsParameters }, callback, errback) => {
@@ -64,9 +65,10 @@ export const createWebRtcStreams = async (
     rtpParameters: RtpParameters;
   }[] = await consumerParametersResponse.json();
 
-  return await Promise.all(
-    consumerParameters.map(async parameter =>
-      await transport.consume(parameter)
-    )
-  );
+  const consumers: Consumer[] = [];
+  for (const consumerParameter of consumerParameters) {
+    consumers.push(await transport.consume(consumerParameter));
+  }
+  return consumers;
 }
+

--- a/next/src/lib/webRtcClient.ts
+++ b/next/src/lib/webRtcClient.ts
@@ -1,0 +1,72 @@
+import { Device } from 'mediasoup-client';
+import { 
+  Consumer,
+  Transport,
+  MediaKind,
+  RtpParameters,
+} from 'mediasoup-client/lib/types';
+
+export const createWebRtcStreams = async (
+  streamId: string
+): Promise<Consumer[]> => {
+
+  const baseUrl = `${process.env.NEXT_PUBLIC_HOST_URL}${process.env.NEXT_PUBLIC_WITHOUT_API ? '' : '/api'}`;
+
+  const routerRtpCapabilitiesResponse = await fetch(
+    `${baseUrl}/mediasoup/router-rtp-capabilities/${streamId}`
+  );
+  const routerRtpCapabilities = await routerRtpCapabilitiesResponse.json();
+  console.log('routerRtpCapabilities: %o', routerRtpCapabilities);
+  const device = new Device();
+  await device.load({ routerRtpCapabilities });
+  const transportParametersResponse = await fetch(
+    `${baseUrl}/mediasoup/streamer-transport-parameters/${streamId}`
+  );
+  const transportParameters = await transportParametersResponse.json();
+  console.log('transportParmaeters: %o', transportParameters);
+  const transport = device.createRecvTransport(transportParameters);
+  transport.on(
+    'connect', 
+    async ({ dtlsParameters }, callback, errback) => {
+      console.log('transport connect');
+      try {
+        await fetch(
+          `${baseUrl}/mediasoup/client-connect/${streamId}/${transportParameters.id}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(dtlsParameters),
+        })
+        callback();
+      } catch (error) {
+        if (error instanceof Error) {
+          errback(error);
+        } else {
+          console.error(`Unknown error at connect: ${error}`);
+        }
+      }
+    }
+  );
+  transport.on('connectionstatechange', (newConnectionState) => {
+    console.log('connection stage: ', newConnectionState);
+  });
+
+  const consumerParametersResponse = await fetch(
+    `${baseUrl}/mediasoup/consumer-parameters/${streamId}/${transportParameters.id}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(device.rtpCapabilities),
+  });
+
+  const consumerParameters: {
+    id: string;
+    producerId: string;
+    kind: MediaKind;
+    rtpParameters: RtpParameters;
+  }[] = await consumerParametersResponse.json();
+
+  return await Promise.all(
+    consumerParameters.map(async parameter =>
+      await transport.consume(parameter)
+    )
+  );
+}

--- a/webrtc/.dockerignore
+++ b/webrtc/.dockerignore
@@ -1,4 +1,1 @@
 node_modules/
-.next/
-.env*
-

--- a/webrtc/.gitignore
+++ b/webrtc/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+dist/

--- a/webrtc/Dockerfile.webrtc.prod
+++ b/webrtc/Dockerfile.webrtc.prod
@@ -1,0 +1,13 @@
+FROM node:20
+
+WORKDIR /app
+
+RUN npm install -g pnpm
+
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install 
+
+COPY . .
+
+CMD ["pnpm", "tsx", "server.ts"]
+

--- a/webrtc/server.ts
+++ b/webrtc/server.ts
@@ -431,6 +431,30 @@ app.post('/mediasoup/consumer-parameters/:resourcesId/:transportId', async (req,
   }
 });
 
+app.post('/mediasoup/resume-consumer/:resourcesId/:transportId', async (req, res) => {
+  const resourcesId = req.params.resourcesId;
+  if (!(resourcesId in resourcesDict)) {
+    res.status(404)
+      .send(`resoures with id ${resourcesId} doesn't exist`);
+    return;
+  }
+
+  const transportId = req.params.transportId;
+  const streamerResource = 
+    resourcesDict[resourcesId]
+    .streamerResources
+    .find(resource => resource.streamerTransport.id === transportId);
+  if (streamerResource == null) {
+    res.status(404)
+      .send(`transportId ${transportId} is not found in resourcesId ${resourcesId}`);
+      return;
+  }
+
+  streamerResource.consumers.forEach(async c => await c.resume());
+
+  res.status(200).send();
+});
+
 const httpServer = createServer(app);
 let connections: Socket[] = [];
 httpServer.listen(3000, () => {

--- a/webrtc/server.ts
+++ b/webrtc/server.ts
@@ -73,6 +73,7 @@ app.post('/id', async (_req, res) => {
       res.status(503).send('All channels are occupied');
       return;
     }
+    console.log(`id: ${availableId} created`);
 
     resourcesDict[availableId] = {
       router: await worker.createRouter({ mediaCodecs }),
@@ -112,11 +113,14 @@ app.post('/whip/:id', async (req, res) => {
     return;
   }
 
-  const router = resourcesDict[resourcesId].router;
+  console.log(`/whip/${resourcesId} post access`);
+
+  const resources = resourcesDict[resourcesId];
+  const router = resources.router;
+  const broadcasterResources = resources.broadcasterResources;
 
   try {
     const localSdpObject = sdpTransform.parse(req.body.toString());
-    console.log('body: ', req.body.toString());
     const rtpCapabilities = sdpCommonUtils.extractRtpCapabilities({
       sdpObject: localSdpObject
     });
@@ -157,9 +161,7 @@ app.post('/whip/:id', async (req, res) => {
     // 既存のtransportが存在していたとしても再利用せず、 
     // 毎回作り直してみる
     const broadcasterTransport = await createWebRtcTransport(router);
-    resourcesDict[resourcesId]
-      .broadcasterResources
-      .broadcasterTransport = broadcasterTransport;
+    broadcasterResources.broadcasterTransport = broadcasterTransport;
 
     broadcasterTransport.observer.on(
       'icestatechange', 
@@ -276,8 +278,10 @@ app.delete('/whip/test-broadcast/:id', async (req, res) => {
   //resourcesDict[resourcesId].router.close();
 
   broadcasterTransport?.close();
+  broadcasterResources.producers = [];
  
   streamerResources.forEach(resources => resources.streamerTransport.close());
+  resourcesDict[resourcesId].streamerResources = [];
 
 
   // TODO : closeしたstreamerTransportを削除する処理
@@ -346,13 +350,17 @@ app.post('/mediasoup/client-connect/:resourcesId/:transportId', async (req, res)
   }
 
   const streamerTransport = streamerResource.streamerTransport;
-  
   const dtlsParameters = req.body;
-  await streamerTransport.connect({ dtlsParameters });
-  streamerTransport.on('icestatechange', (iceState) =>
-    console.log('streamer transport ice change: ', iceState)
-  );
-  res.status(200).send('client connect callback handled');
+  try {
+    // 動くバージョンではなぜかawaitが無い...
+    streamerTransport.connect({ dtlsParameters });
+    streamerTransport.on('icestatechange', (iceState) =>
+      console.log('streamer transport ice change: ', iceState)
+    );
+    res.status(200).send('client connect callback handled');
+  } catch (err) {
+    res.status(500).send(`error: ${err}`);
+  }
 });
 
 app.post('/mediasoup/consumer-parameters/:resourcesId/:transportId', async (req, res) => {
@@ -388,35 +396,39 @@ app.post('/mediasoup/consumer-parameters/:resourcesId/:transportId', async (req,
     kind: MediaKind;
     rtpParameters: RtpParameters;
   };
-  const consumerParameters: ConsumerParameters[] = [];
-  for (const producer of broadcasterResources.producers) {
-    const canConsume = router.canConsume({
-      producerId: producer.id,
-      rtpCapabilities: clientCapabilities,
-    });
-    if (canConsume) {
-      const consumer = await streamerResource
-        .streamerTransport.consume({
-          producerId: producer.id,
-          rtpCapabilities: clientCapabilities,
-          paused: true,
-        });
-      console.log('consumer created: ', consumer.id, consumer.kind);
-      streamerResource.consumers.push(consumer);
-      consumerParameters.push({
-        id: consumer.id,
-        producerId: consumer.producerId,
-        kind: consumer.kind,
-        rtpParameters: consumer.rtpParameters,
+  try {
+    const consumerParameters: ConsumerParameters[] = [];
+    for (const producer of broadcasterResources.producers) {
+      const canConsume = router.canConsume({
+        producerId: producer.id,
+        rtpCapabilities: clientCapabilities,
       });
-    } else {
-      console.warn(
-        `resourcesId ${resourcesId} cannot consume producer ${producer.id}`
-      );
+      if (canConsume) {
+        const consumer = await streamerResource
+          .streamerTransport.consume({
+            producerId: producer.id,
+            rtpCapabilities: clientCapabilities,
+            paused: true,
+          });
+        console.log('consumer created: ', consumer.id, consumer.kind);
+        streamerResource.consumers.push(consumer);
+        consumerParameters.push({
+          id: consumer.id,
+          producerId: consumer.producerId,
+          kind: consumer.kind,
+          rtpParameters: consumer.rtpParameters,
+        });
+      } else {
+        console.warn(
+          `resourcesId ${resourcesId} cannot consume producer ${producer.id}`
+        );
+      }
     }
-  }
 
-  res.status(200).send(consumerParameters);
+    res.status(200).send(consumerParameters);
+  } catch (error) {
+    res.status(500).send(`error: ${error}`);
+  }
 });
 
 const httpServer = createServer(app);

--- a/webrtc/server.ts
+++ b/webrtc/server.ts
@@ -348,7 +348,10 @@ app.post('/mediasoup/client-connect/:resourcesId/:transportId', async (req, res)
   const streamerTransport = streamerResource.streamerTransport;
   
   const dtlsParameters = req.body;
-  streamerTransport.connect({ dtlsParameters });
+  await streamerTransport.connect({ dtlsParameters });
+  streamerTransport.on('icestatechange', (iceState) =>
+    console.log('streamer transport ice change: ', iceState)
+  );
   res.status(200).send('client connect callback handled');
 });
 
@@ -373,6 +376,8 @@ app.post('/mediasoup/consumer-parameters/:resourcesId/:transportId', async (req,
       return;
   }
 
+  console.log('consumer-parameters: ',resourcesId, transportId); 
+
   const broadcasterResources =
     resourcesDict[resourcesId].broadcasterResources;
   const router = resourcesDict[resourcesId].router;
@@ -396,6 +401,7 @@ app.post('/mediasoup/consumer-parameters/:resourcesId/:transportId', async (req,
           rtpCapabilities: clientCapabilities,
           paused: true,
         });
+      console.log('consumer created: ', consumer.id, consumer.kind);
       streamerResource.consumers.push(consumer);
       consumerParameters.push({
         id: consumer.id,
@@ -405,7 +411,8 @@ app.post('/mediasoup/consumer-parameters/:resourcesId/:transportId', async (req,
       });
     } else {
       console.warn(
-        `resourcesId ${resourcesId} cannot consume producer ${producer.id}`);
+        `resourcesId ${resourcesId} cannot consume producer ${producer.id}`
+      );
     }
   }
 


### PR DESCRIPTION
技術調査時に動画が再生されない問題を解消する

pausedで作成されたサーバ側consumerを、クライアント側のconsumer作成後に consumer.resume() することで mediasoup 側の意図する適切な処理が一通り完成するとのことで、それに準拠

動画が問題なく再生されるようになった（closes #1 ）、視聴者が複数いる状況にも一応対応できる

ただし、リソース制限や解放がまだなので、無限に視聴者が増えたり、視聴用ページを頻繁に再読み込みされるとよろしくないことになる

