### PR TITLE
再起動後に出るSDP fingerprint関連のエラーへの対策を追加

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,8 @@ services:
     environment:
       DEBUG: "mediasoup*,videmus:webrtc*"
       TZ: 'Asia/Tokyo'
+      DTLS_CERT: ./dtls-cert.pem
+      DTLS_KEY: ./dtls-key.pem
     ports:
       - 44400:44400/udp
       - 44400:44400/tcp
@@ -42,6 +44,8 @@ services:
       - ./webrtc:/workspace/webrtc
       - /workspace/webrtc/node_modules
       - /workspace/node_modules
+      - ./webrtc/dtls-cert.pem:/workspace/webrtc/dtls-cert.pem
+      - ./webrtc/dtls-key.pem:/workspace/webrtc/dtls-key.pem
     depends_on:
       database-preparation:
         condition: service_completed_successfully 

--- a/webrtc/src/server.ts
+++ b/webrtc/src/server.ts
@@ -32,7 +32,6 @@ import { broadcastIds } from 'videmus-database/db/schema';
 
 const test = await db.select().from(broadcastIds);
 debug(test);
-debug(process.env)
 
 const app = express();
 app.use(express.json());
@@ -70,11 +69,12 @@ const worker: Worker = await createWorker({
   logTags: [ 'info', 'ice', 'dtls', 'rtp', 'rtcp' ],
   rtcMinPort: 44400,
   rtcMaxPort: 44410,
+  dtlsCertificateFile: process.env.DTLS_CERT,
+  dtlsPrivateKeyFile: process.env.DTLS_KEY,
 });
 debug('Worker created');
 
-const webRtcServer: WebRtcServer | undefined = //undefined
-await worker.createWebRtcServer({
+const webRtcServer: WebRtcServer = await worker.createWebRtcServer({
   listenInfos: [
     {
       protocol: 'udp',
@@ -90,8 +90,6 @@ await worker.createWebRtcServer({
     },
   ],
 })
-
-//worker.appData.webRtcServer = webRtcServer;
 
 const resourcesDict: ResourcesDict = {};
 


### PR DESCRIPTION
証明書ファイルを指定しないと毎起動毎に新しいものが生成され、
それがOBSなどにキャッシュされたものと食い違うとエラーになっていたらしい
生成したファイルを環境変数+docker volumeで指定できるように修正