### PR TITLE
Next.jsアプリケーションにおけるmediasoupをdevDependenciesに変更

### DIFF
--- a/next/package.json
+++ b/next/package.json
@@ -13,7 +13,6 @@
     "@heroicons/react": "^2.2.0",
     "clsx": "^2.1.1",
     "hono": "^4.9.8",
-    "mediasoup": "^3.16.3",
     "mediasoup-client": "^3.12.2",
     "mysql2": "3.14.1",
     "nanoid": "^5.1.5",
@@ -31,6 +30,7 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@types/uuid": "^10.0.0",
+    "mediasoup": "^3.16.3",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.8.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,9 +44,6 @@ importers:
       hono:
         specifier: ^4.9.8
         version: 4.9.8
-      mediasoup:
-        specifier: ^3.16.3
-        version: 3.16.3
       mediasoup-client:
         specifier: ^3.12.2
         version: 3.12.2
@@ -93,6 +90,9 @@ importers:
       '@types/uuid':
         specifier: ^10.0.0
         version: 10.0.0
+      mediasoup:
+        specifier: ^3.16.3
+        version: 3.16.3
       postcss:
         specifier: ^8.5.6
         version: 8.5.6

--- a/webrtc/Dockerfile.webrtc.prod
+++ b/webrtc/Dockerfile.webrtc.prod
@@ -1,4 +1,4 @@
-FROM node:20-slim AS build
+FROM node:22-slim AS build
 
 WORKDIR /workspace/webrtc
 
@@ -18,7 +18,7 @@ COPY ./webrtc/tsconfig.json ./webrtc/esbuild.config.ts /workspace/webrtc/
 RUN pnpm build
 
 
-FROM node:20-slim AS node_modules
+FROM node:22-slim AS node_modules
 WORKDIR /workspace/webrtc
 
 RUN npm install -g pnpm
@@ -35,7 +35,7 @@ RUN pnpm install --prod --filter videmus-webrtc --filter videmus-database
 #RUN ls ./node_modules/tsx/dist
 
 
-FROM gcr.io/distroless/nodejs20:debug
+FROM gcr.io/distroless/nodejs22:debug
 
 WORKDIR /workspace/webrtc
 


### PR DESCRIPTION
Vercel 上などデプロイ先で mediasoup binary がインストールされてしまうので、devDependencies に入れるのが適切そう。